### PR TITLE
[#3] env - morgan 미들웨어 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1703,6 +1703,15 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "batch": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
@@ -5401,6 +5410,42 @@
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "morgan": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",
+      "integrity": "sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "~2.0.1",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        }
       }
     },
     "move-concurrently": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "style-loader": "^1.2.1",
     "url-loader": "^4.1.0",
     "webpack-dev-server": "^3.11.0",
-    "webpack-merge": "^5.0.9"
+    "webpack-merge": "^5.0.9",
+    "morgan": "^1.10.0"
   },
   "scripts": {
     "dev:server": "cp ./server/.env.dev ./server/.env && nodemon ./server/index",

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,6 @@
 require('dotenv').config();
 const express = require('express');
+const morgan = require('morgan');
 const { urlencoded, json } = require('express');
 const apiRoutes = require('./routes');
 const { SERVER_PORT } = require('./utils/constants');
@@ -11,6 +12,8 @@ app.use(urlencoded({ extended: true }), json());
 // urlencoeded 함수를 사용하면 자동으로 req 객체에 body property를 넣어줌 -> 그걸 json화
 // https://sjh836.tistory.com/154 참고 했음
 // 주석은 다음 PR에서 제거할 계획
+
+app.use(morgan('dev'));
 
 app.use('/api', apiRoutes);
 app.use(errorHandler);


### PR DESCRIPTION
## 요약
- morgan 추가 및 dev 설정


## 추가 설명 
- morgan 미들웨어를 추가하여 'dev' 설정을 주면, 아래 그림의 마지막 두 줄처럼 요청 메소드, 상태코드 등을 색으로 구분하여 터미널에 띄워주기 때문에 개발시에 유용합니다.

![image](https://user-images.githubusercontent.com/34447105/88661986-5000c400-d114-11ea-879c-1aa170483df2.png)

```:method :url :status :response-time ms - :res[content-length]```


## 관련 이슈
- #3 